### PR TITLE
Fix testing bug

### DIFF
--- a/pyrob/tasks/task_7_5.py
+++ b/pyrob/tasks/task_7_5.py
@@ -18,12 +18,14 @@ class Task:
         d = 0
         _d = 0
 
-        while not rob.wall_is_on_the_right():
+        while True:
             if _d == 0:
                 pos = rob.get_pos()
                 rob.set_cell_type(pos[0], pos[1], rob.CELL_TO_BE_FILLED)
                 d += 1
                 _d = d
+            if rob.wall_is_on_the_right():
+                break
             rob.move_right()
             _d -= 1
 


### PR DESCRIPTION
![bug-in-task_27-task_7_5](https://user-images.githubusercontent.com/10737305/64191588-7aed8400-ce81-11e9-859c-fe3a9b8cfb04.png)
If the rightmost painted cell has to be on the border of the robot pitch
the cell is not painted and task testing system reports an error wrongly.

Если крайняя клетка, которую нужно закрасить, на границе, тестирующая система ее не включает в задание.