### PR TITLE
Fix confusing error msg on mov() call

### DIFF
--- a/pyrob/core.py
+++ b/pyrob/core.py
@@ -334,7 +334,7 @@ def is_parking_point():
 def mov(register, value):
     global registers
 
-    assert registers is not None
+    assert "registers" in globals(), "Dictionary `registers` is not defined because field is not set"
 
     registers[register] = value
 


### PR DESCRIPTION
If mov() function is called when field is
not set, a NameError is raised in line where
AssertionError is expected. I add assertion msg
for the case.

Если вызвать  `mov()` до создания поля возникает `NameError`.
```
>>> from pyrob.api import *
>>> mov('ax', 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/anton/pyrob-fork/pyrob/utils.py", line 16, in wrapper
    ret = f(*args, **kwargs)
  File "/home/anton/pyrob-fork/pyrob/utils.py", line 71, in wrapper
    return f(*args, **kwargs)
  File "/home/anton/pyrob-fork/pyrob/core.py", line 337, in mov
    assert registers is not None
NameError: name 'registers' is not defined
>>> 
```
Сделал так, чтобы возбуждалась `AssertionError` и добавил к ней сообщение.